### PR TITLE
Add Redis-backed memory with Ollama generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,13 @@ This project is released under the MIT License.
 
 - Thanks to the developers of the ESP32 Arduino Core, TinyGPS++, U8g2, and other libraries used in this project.
 - Appreciation to the ESP32 community for ongoing support and inspiration.
+
+---
+
+## NAN Memory System Prototype
+
+This repository also includes a small Python prototype located in `nan.py` and
+`nan_cli.py`. The updated version stores all agent memory in a Redis server and
+can generate memory items using a local [Ollama](https://ollama.ai) instance.
+Run `python3 nan_cli.py` to launch an interactive CLI for experimenting with
+agents, their Redis-backed memory stores, and on-demand text generation.

--- a/nan.py
+++ b/nan.py
@@ -1,0 +1,114 @@
+"""Core classes for the NAN multi-agent memory system using Redis storage and
+Ollama for text generation."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Iterable, List
+
+import redis
+import requests
+
+
+REDIS_HOST = "localhost"
+REDIS_PORT = 6379
+
+_REDIS = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
+
+
+class MemoryPool:
+    """Manage detached memory chunks for agents using Redis."""
+
+    def __init__(self, redis_client: redis.Redis = _REDIS) -> None:
+        self.redis = redis_client
+
+    def _key(self, memory_id: str) -> str:
+        return f"pool:{memory_id}"
+
+    def add_memory(self, memory: Iterable[str]) -> str:
+        """Add a memory list to the pool and return a unique id."""
+        memory_id = str(uuid.uuid4())
+        self.redis.set(self._key(memory_id), json.dumps(list(memory)))
+        self.redis.sadd("pool_ids", memory_id)
+        return memory_id
+
+    def get_memory(self, memory_id: str) -> List[str] | None:
+        data = self.redis.get(self._key(memory_id))
+        return json.loads(data) if data else None
+
+    def remove_memory(self, memory_id: str) -> List[str] | None:
+        memory = self.get_memory(memory_id)
+        if memory is not None:
+            self.redis.delete(self._key(memory_id))
+            self.redis.srem("pool_ids", memory_id)
+        return memory
+
+    def list_memory_ids(self) -> List[str]:
+        return list(self.redis.smembers("pool_ids"))
+
+
+class Agent:
+    """Simple agent holding its own memory in Redis."""
+
+    def __init__(self, agent_id: str, redis_client: redis.Redis = _REDIS) -> None:
+        self.id = agent_id
+        self.redis = redis_client
+
+    def _key(self) -> str:
+        return f"agent:{self.id}:mem"
+
+    def add_memory(self, item: str) -> None:
+        self.redis.rpush(self._key(), item)
+
+    def query_memory(self) -> List[str]:
+        return self.redis.lrange(self._key(), 0, -1)
+
+    def clear_memory(self) -> None:
+        self.redis.delete(self._key())
+
+    def detach_memory(self, pool: MemoryPool) -> str:
+        memory = self.query_memory()
+        memory_id = pool.add_memory(memory)
+        self.clear_memory()
+        return memory_id
+
+    def attach_memory(self, pool: MemoryPool, memory_id: str) -> bool:
+        memory = pool.remove_memory(memory_id)
+        if memory is not None:
+            self.clear_memory()
+            if memory:
+                self.redis.rpush(self._key(), *memory)
+            return True
+        return False
+
+    def save_memory(self, filepath: str) -> None:
+        with open(filepath, "w", encoding="utf-8") as f:
+            for item in self.query_memory():
+                f.write(f"{item}\n")
+
+    def load_memory(self, filepath: str) -> None:
+        self.clear_memory()
+        with open(filepath, "r", encoding="utf-8") as f:
+            items = [line.strip() for line in f]
+        if items:
+            self.redis.rpush(self._key(), *items)
+
+
+class OllamaClient:
+    """Minimal client for interacting with an Ollama server."""
+
+    def __init__(self, base_url: str = "http://localhost:11434", model: str = "llama2") -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    def generate(self, prompt: str) -> str:
+        resp = requests.post(
+            f"{self.base_url}/api/generate",
+            json={"model": self.model, "prompt": prompt, "stream": False},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("response", "")
+

--- a/nan_cli.py
+++ b/nan_cli.py
@@ -1,0 +1,150 @@
+"""Command line interface for testing the NAN memory system with Redis storage
+and Ollama integration."""
+
+import argparse
+from typing import Dict
+
+from nan import Agent, MemoryPool, OllamaClient
+
+agents: Dict[str, Agent] = {}
+POOL = MemoryPool()
+OLLAMA = OllamaClient()
+
+def spawn_agent() -> str:
+    agent_id = str(len(agents) + 1)
+    agents[agent_id] = Agent(agent_id)
+    return agent_id
+
+def get_agent(agent_id: str) -> Agent:
+    if agent_id not in agents:
+        raise ValueError(f"Agent {agent_id} does not exist")
+    return agents[agent_id]
+
+
+def cmd_spawn(_args):
+    agent_id = spawn_agent()
+    print(f"Spawned agent {agent_id}")
+
+
+def cmd_add(args):
+    agent = get_agent(args.agent_id)
+    agent.add_memory(args.item)
+    print(f"Added memory to agent {agent.id}")
+
+
+def cmd_generate(args):
+    """Generate text from Ollama and store it in the agent's memory."""
+    agent = get_agent(args.agent_id)
+    text = OLLAMA.generate(args.prompt)
+    agent.add_memory(text)
+    print(text)
+
+
+def cmd_query(args):
+    agent = get_agent(args.agent_id)
+    print("\n".join(agent.query_memory()))
+
+
+def cmd_clear(args):
+    agent = get_agent(args.agent_id)
+    agent.clear_memory()
+    print(f"Cleared memory for agent {agent.id}")
+
+
+def cmd_detach(args):
+    agent = get_agent(args.agent_id)
+    mem_id = agent.detach_memory(POOL)
+    print(f"Detached memory from agent {agent.id} -> {mem_id}")
+
+
+def cmd_attach(args):
+    agent = get_agent(args.agent_id)
+    success = agent.attach_memory(POOL, args.memory_id)
+    if success:
+        print(f"Attached memory {args.memory_id} to agent {agent.id}")
+    else:
+        print(f"Memory ID {args.memory_id} not found")
+
+
+def cmd_list_agents(_args):
+    for aid in agents:
+        print(aid)
+
+
+def cmd_list_pool(_args):
+    for mid in POOL.list_memory_ids():
+        print(mid)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="NAN Memory System CLI")
+    sub = parser.add_subparsers(dest="command")
+
+    spawn = sub.add_parser("spawn", help="Spawn a new agent")
+    spawn.set_defaults(func=cmd_spawn)
+
+    add = sub.add_parser("add", help="Add memory to an agent")
+    add.add_argument("agent_id")
+    add.add_argument("item")
+    add.set_defaults(func=cmd_add)
+
+    query = sub.add_parser("query", help="Query agent memory")
+    query.add_argument("agent_id")
+    query.set_defaults(func=cmd_query)
+
+    clear = sub.add_parser("clear", help="Clear agent memory")
+    clear.add_argument("agent_id")
+    clear.set_defaults(func=cmd_clear)
+
+    gen = sub.add_parser("generate", help="Generate text with Ollama and store it")
+    gen.add_argument("agent_id")
+    gen.add_argument("prompt")
+    gen.set_defaults(func=cmd_generate)
+
+    detach = sub.add_parser("detach", help="Detach agent memory to pool")
+    detach.add_argument("agent_id")
+    detach.set_defaults(func=cmd_detach)
+
+    attach = sub.add_parser("attach", help="Attach memory from pool to agent")
+    attach.add_argument("agent_id")
+    attach.add_argument("memory_id")
+    attach.set_defaults(func=cmd_attach)
+
+    la = sub.add_parser("list_agents", help="List all agents")
+    la.set_defaults(func=cmd_list_agents)
+
+    lp = sub.add_parser("list_pool", help="List memory ids in pool")
+    lp.set_defaults(func=cmd_list_pool)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    if argv:
+        args = parser.parse_args(argv)
+        if hasattr(args, "func"):
+            args.func(args)
+        else:
+            parser.print_help()
+        return
+
+    # Interactive mode
+    while True:
+        try:
+            line = input("nan> ")
+        except EOFError:
+            break
+        if line.strip().lower() in {"exit", "quit"}:
+            break
+        parts = line.split()
+        if not parts:
+            continue
+        args = parser.parse_args(parts)
+        if hasattr(args, "func"):
+            args.func(args)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- refactor MemoryPool and Agent to store data in Redis
- add OllamaClient class and CLI command for text generation
- document Redis and Ollama usage in README

## Testing
- `python3 - <<'EOF'
import nan_cli
nan_cli.main(["--help"])
EOF`
- `python3 - <<'EOF'
import nan_cli
try:
    nan_cli.main(["spawn"])
    nan_cli.main(["add", "1", "hello"])
    nan_cli.main(["query", "1"])
except Exception as e:
    print("Error:", e)
EOF`


------
https://chatgpt.com/codex/tasks/task_e_683fd2ca1f208323b70a6ce2903378d5