### PR TITLE
Add network scanner GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,15 @@ This repository also includes a small Python prototype located in `nan.py` and
 can generate memory items using a local [Ollama](https://ollama.ai) instance.
 Run `python3 nan_cli.py` to launch an interactive CLI for experimenting with
 agents, their Redis-backed memory stores, and on-demand text generation.
+
+## Network Scanner Utility
+
+A simple Python-based network scanner is included in `net_gui.py`. It discovers devices on your local network using ARP and displays them in a Tkinter GUI. Double-click a listed host to open a web-based SSH terminal via the `webssh` package.
+
+Run the scanner with:
+
+```bash
+python3 net_gui.py
+```
+
+Ensure `scapy` and `webssh` are installed (use `pip install scapy webssh`).

--- a/net_gui.py
+++ b/net_gui.py
@@ -1,0 +1,94 @@
+import socket
+import subprocess
+import threading
+import webbrowser
+from tkinter import Tk, ttk, Button, Scrollbar, VERTICAL, RIGHT, Y, LEFT, BOTH
+
+from scapy.all import ARP, Ether, srp
+
+
+def scan_network(subnet: str):
+    """Scan subnet using ARP requests."""
+    arp = ARP(pdst=subnet)
+    ether = Ether(dst="ff:ff:ff:ff:ff:ff")
+    packet = ether / arp
+    result = srp(packet, timeout=3, verbose=False)[0]
+    devices = []
+    for _, received in result:
+        ip = received.psrc
+        mac = received.hwsrc
+        try:
+            hostname = socket.gethostbyaddr(ip)[0]
+        except socket.herror:
+            hostname = ""
+        devices.append({"ip": ip, "mac": mac, "hostname": hostname})
+    return devices
+
+
+class NetworkGUI:
+    def __init__(self, root, subnet="192.168.1.0/24"):
+        self.root = root
+        self.subnet = subnet
+        self.tree = ttk.Treeview(
+            root, columns=("ip", "hostname", "mac"), show="headings"
+        )
+        self.tree.heading("ip", text="IP")
+        self.tree.heading("hostname", text="Hostname")
+        self.tree.heading("mac", text="MAC")
+        self.tree.pack(side=LEFT, fill=BOTH, expand=True)
+        scroll = Scrollbar(root, orient=VERTICAL, command=self.tree.yview)
+        scroll.pack(side=RIGHT, fill=Y)
+        self.tree.configure(yscroll=scroll.set)
+        self.tree.tag_configure("active", background="lightgreen")
+        self.tree.bind("<Double-1>", self.on_double_click)
+        Button(root, text="Scan", command=self.scan).pack(side=LEFT)
+        self.webssh_process = None
+
+    def start_webssh(self):
+        if self.webssh_process is None or self.webssh_process.poll() is not None:
+            self.webssh_process = subprocess.Popen(
+                [
+                    "wssh",
+                    "--address",
+                    "127.0.0.1",
+                    "--port",
+                    "8888",
+                    "--policy",
+                    "autoadd",
+                    "--redirect",
+                    "False",
+                ]
+            )
+
+    def scan(self):
+        def _scan():
+            devices = scan_network(self.subnet)
+            self.tree.delete(*self.tree.get_children())
+            for dev in devices:
+                self.tree.insert(
+                    "",
+                    "end",
+                    values=(dev["ip"], dev["hostname"], dev["mac"]),
+                    tags=("active",),
+                )
+
+        threading.Thread(target=_scan, daemon=True).start()
+
+    def on_double_click(self, event):
+        item = self.tree.selection()
+        if not item:
+            return
+        ip = self.tree.item(item[0], "values")[0]
+        self.start_webssh()
+        webbrowser.open(f"http://localhost:8888/?hostname={ip}&port=22")
+
+
+def main():
+    root = Tk()
+    root.title("Network Scanner")
+    app = NetworkGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `net_gui.py` to scan local network using scapy and show hosts in a Tkinter GUI
- allow double‑clicking a host to open a web-based SSH terminal (via webssh)
- document the new script in README

## Testing
- `python3 -m py_compile net_gui.py`
- *(fail: GUI can't launch in headless env)*

------
https://chatgpt.com/codex/tasks/task_e_68435f3df08c8323a5f435c0a90e247e